### PR TITLE
fixed http.request 'Transfer-Encoding: chunked' bug

### DIFF
--- a/lib/digestauth.js
+++ b/lib/digestauth.js
@@ -10,7 +10,6 @@ var util = require('./util.js');
 // func checksum
 
 function checksum(opt, body) {
-
 	var hmac = crypto.createHmac('sha1', conf.SECRET_KEY);
 	hmac.update(opt.path + "\n");
 	if (body) {
@@ -27,14 +26,14 @@ function Client() {
 }
 
 Client.prototype.auth = function(opt, params) {
-	opt.headers['Authorization'] = 'QBox ' + conf.ACCESS_KEY + ':' + checksum(opt, params)
+	opt.headers['Authorization'] = 'QBox ' + conf.ACCESS_KEY + ':' + checksum(opt, params);
 };
 
 Client.prototype.execute = function(url, params, onresp, onerror) {
 
 	var u = uri.parse(url);
 	var opt = {
-		headers: {},
+		headers: {'Accept': 'application/json', 'Accept-Encoding': 'gzip, deflate'},
 		host: u.hostname,
 		port: u.port,
 		path: u.path,
@@ -49,11 +48,13 @@ Client.prototype.execute = function(url, params, onresp, onerror) {
 	}
 
 	var body;
-	var binary;
+	var binary = false;
+    var contentLength = 0;
+	var contentType = 'application/x-www-form-urlencoded';
 	if (params) {
 		if (params instanceof util.Binary) {
-			opt.headers['Content-Type'] = 'application/octet-stream';
-			opt.headers['Content-Length'] = params.bytes;
+			contentType = 'application/octet-stream';
+			contentLength = params.bytes;
 			binary = true;
 		} else {
 			if (typeof params === 'string') {
@@ -61,10 +62,12 @@ Client.prototype.execute = function(url, params, onresp, onerror) {
 			} else {
 				body = querystring.stringify(params);
 			}
-			opt.headers['Content-Type'] = 'application/x-www-form-urlencoded';
-			opt.headers['Content-Length'] = params.length;
+			contentLength = params.length;
 		}
 	}
+    opt.headers['Content-Type'] = contentType;
+    opt.headers['Content-Length'] = contentLength;
+
 	this.auth(opt, body);
 
 	var req = proto.request(opt, onresp);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qiniu",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Node wrapper for Qiniu Resource (Cloud) Storage API",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
原 NodeJS 发送 HTTP 请求时 body 部分会加 0 ，导致预发布环境签名认证失败：

2012/07/19 11:27:09 [WARN][qbox.us/servend/account] account_interface.go:102: GetAuthExt failed:
 ==> invalid argument ~ GetAuthExt
 ==> invalid argument ~ DigestAuth
 ==> invalid argument ~ digest_auth.Checksum

截取到的 NodeJS 请求如下：

POST /drop/test_image_bucket HTTP/1.1
Authorization: QBox a3pwrjafpZttICsgppnMKEk8oksvGNSSfjkjTlff:udlhyF_TO33dAmfSM3ed65NN1wA=
Host: m1.qbox.me:13003
Connection: keep-alive
Transfer-Encoding: chunked

0

^C

而 Ruby SDK 发送的请求是 OK 的，如下：

build@mail:~/proc/rs$ nc -l 13003
POST /drop/test_image_bucket HTTP/1.1
Accept: application/json
Accept-Encoding: gzip, deflate
User-Agent: Qiniu-RS-Ruby-SDK-2.1.2()
Authorization: QBox a3pwrjafpZttICsgppnMKEk8oksvGNSSfjkjTlff:udlhyF_TO33dAmfSM3ed65NN1wA=
Content-Type: application/x-www-form-urlencoded
Host: m1.qbox.me:13003
