### PR TITLE
get Error: 'First argument needs to be a number, array or string' with m...

### DIFF
--- a/lib/rs.js
+++ b/lib/rs.js
@@ -143,7 +143,7 @@ Service.prototype.uploadWithToken = function(uploadToken, stream, key, mimeType,
   var form = formstream();
   form.field('action', actionString);
   form.field('params', callbackQueryString);
-  form.field('multipart', true);
+  form.field('multipart', 'true');
   form.field('auth', uploadToken);
   form.stream('file', stream, filename, mimeType);
   form = new util.Form(form, form.headers()['Content-Type']);


### PR DESCRIPTION
...ime@1.2.10

buffer.js:238
        throw new Error('First argument needs to be a number, ' +
              ^
Error: First argument needs to be a number, array or string.
    at new Buffer (buffer.js:238:15)
    at FormStream.field (./formstream/lib/formstream.js:135:16)
    at Service.uploadWithToken (./lib/rs.js:146:8)
    at Object.oncomplete (./lib/rs.js:183:10)
