### PR TITLE
当发起post请求的时候，在http头中加入Content-Length信息

### DIFF
--- a/qiniu/rpc.js
+++ b/qiniu/rpc.js
@@ -35,10 +35,14 @@ function post(uri, form, headers, onresp) {
   headers['User-Agent'] = headers['User-Agent'] || conf.USER_AGENT;
 
   var content = null;
+  var content.length = 0;
   if (Buffer.isBuffer(form) || typeof form === 'string') {
     content = form;
+    contentLength = content.length;
     form = null;
   }
+  
+  headers['Content-Length'] = contentLength;
 
   var req = urllib.request(uri, {
     headers: headers,


### PR DESCRIPTION
在百度app engine上链接qiniu ，删除文件的时候会提示http 411错误，调试了很久，发现SDK在发出post请求的时候不会设置Content-Length
