### PR TITLE
support key with query

### DIFF
--- a/qiniu/rs.js
+++ b/qiniu/rs.js
@@ -230,8 +230,8 @@ GetPolicy.prototype.makeRequest = function(baseUrl, mac) {
 
   return baseUrl + '&token=' + downloadToken;
 }
-
-function makeBaseUrl(domain, key) {
+// query like '-thumbnail', '?imageMogr2/thumbnail/960x' and so on
+function makeBaseUrl(domain, key, query) {
   key = new Buffer(key);
-  return 'http://' + domain + '/' + querystring.escape(key);
+  return 'http://' + domain + '/' + querystring.escape(key) + (query||'');
 }


### PR DESCRIPTION
我的key带有参数：`?imageView2/1/w/64/h/64`，签名得到的url: http://temp-cloud3edu-com.qiniudn.com/yTWNJ8G1PT%2F%C3%A7%C2%8B%C2%97.jpg%3FimageView2%2F1%2Fw%2F64%2Fh%2F64%3FimageView2%2F1%2Fw%2F64%2Fh%2F64?e=1408784355&token=_NXt69baB3oKUcLaHfgV5Li-W_LQ-lhJPhavHIc_:DhoYgHasg_CqzVenKDl0PvZ19e8=
返回结果为`{"error":"Not Found"}`

解决方法：

```
function makeBaseUrl(domain, key) {
key = new Buffer(key);
return 'http://' + domain + '/' + querystring.escape(key);
}
```

这里querystring.escape会把query转掉，整个key就错了，应该提供个参数，可以传query

```
function makeBaseUrl(domain, key, query) {
key = new Buffer(key);
return 'http://' + domain + '/' + querystring.escape(key) + query; // query like '?imageView2/1/w/64/h/64'
}
```
