### PR TITLE
add insertOnly and fsizeLimit params for UploadToken

### DIFF
--- a/qiniu/rs.js
+++ b/qiniu/rs.js
@@ -196,6 +196,12 @@ PutPolicy.prototype.getFlags = function(putPolicy) {
     flags['fopTimeout'] = this.fopTimeout;
   }
   flags['deadline'] = this.expires + Math.floor(Date.now() / 1000);
+  if (this.fsizeLimit != null) {
+    flags['fsizeLimit'] = this.fsizeLimit;
+  }
+  if (this.insertOnly != null) {
+    flags['insertOnly'] = this.insertOnly;
+  }
   return flags;
 }
 


### PR DESCRIPTION
add insertOnly and fsizeLimit params for UploadToken 

insertOnly 
限定为“新增”语意 
如果设置为非0值，则无论scope设置为什么形式，仅能以新增模式上传文件。 

fsizeLimit 
限定上传文件的大小，单位：字节（Byte） 
超过限制的上传内容会被判为上传失败，返回413状态码。 

REF. 
http://developer.qiniu.com/docs/v6/api/reference/security/put-policy.html 
