### PR TITLE
示例代码返回401错误

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -169,7 +169,7 @@ function PutPolicy(scope, callbackUrl, callbackBody, returnUrl, returnBody,
 
 ```{javascript}
 function uptoken(bucketname) {
-  var putPolicy = new qiniu.rs.PutPolicy(bucketname);
+  var putPolicy = new qiniu.rs.PutPolicy({scope: bucketname});
   //putPolicy.callbackUrl = callbackUrl;
   //putPolicy.callbackBody = callbackBody;
   //putPolicy.returnUrl = returnUrl;


### PR DESCRIPTION
按照修改处原来的写法，会出现如下错误：
```
{ code: 401, error: 'expired token' }
```

同时官方文档也需要修改一下： http://developer.qiniu.com/docs/v6/sdk/nodejs-sdk.html
