### PR TITLE
Update resume.js

### DIFF
--- a/qiniu/storage/resume.js
+++ b/qiniu/storage/resume.js
@@ -143,7 +143,7 @@ function putReq(config, uploadToken, key, rsStream, rsStreamLen, putExtra,
     } catch (e) {}
   }
 
-  var isend = rsStream._readableState.ended;
+  var isEnd = rsStream._readableState.ended;
   
   //check when to mkblk
   rsStream.on('data', function(chunk) {
@@ -181,7 +181,7 @@ function putReq(config, uploadToken, key, rsStream, rsStreamLen, putExtra,
             }
 
             rsStream.resume();
-            if (isend) {
+            if (isEnd) {
                 mkfileReq(upDomain, uploadToken, fileSize, finishedCtxList, key, putExtra, callbackFunc);
             }
           }
@@ -193,7 +193,7 @@ function putReq(config, uploadToken, key, rsStream, rsStreamLen, putExtra,
   //check when to mkfile
   rsStream.on('end', function() {
     //console.log("end");
-    if (!isend) {
+    if (!isEnd) {
       mkfileReq(upDomain, uploadToken, fileSize, finishedCtxList, key,
       putExtra, callbackFunc);
     }

--- a/qiniu/storage/resume.js
+++ b/qiniu/storage/resume.js
@@ -143,6 +143,8 @@ function putReq(config, uploadToken, key, rsStream, rsStreamLen, putExtra,
     } catch (e) {}
   }
 
+  var isend = rsStream._readableState.ended;
+  
   //check when to mkblk
   rsStream.on('data', function(chunk) {
     readLen += chunk.length;
@@ -179,6 +181,9 @@ function putReq(config, uploadToken, key, rsStream, rsStreamLen, putExtra,
             }
 
             rsStream.resume();
+            if (isend) {
+                mkfileReq(upDomain, uploadToken, fileSize, finishedCtxList, key, putExtra, callbackFunc);
+            }
           }
         });
       }
@@ -188,8 +193,10 @@ function putReq(config, uploadToken, key, rsStream, rsStreamLen, putExtra,
   //check when to mkfile
   rsStream.on('end', function() {
     //console.log("end");
-    mkfileReq(upDomain, uploadToken, fileSize, finishedCtxList, key,
+    if (!isend) {
+      mkfileReq(upDomain, uploadToken, fileSize, finishedCtxList, key,
       putExtra, callbackFunc);
+    }
   });
 }
 


### PR DESCRIPTION
在小于100kb(大概值)的文件上传中,rsStream 的 ‘data’和‘end’会先后触发. 导致mkfileReq方法中finishedCtxList为空,上传文件失败.
添加了一个标记位,如果文件已经读取结束.直接在mkblkReq的callback调用mkfileReq.