### PR TITLE
Safe encode url

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,16 +47,16 @@
     "email": "jinxinxin@qiniu.com"
   }],
   "engines": [
-    "node >= 0.4.7"
+    "node >= 4"
   ],
   "dependencies": {
-    "mime": "1.3.6",
-    "formstream": "1.1.0",
-    "crc32": "0.2.2",
-    "urllib": "2.22.0",
     "agentkeepalive": "3.3.0",
+    "crc32": "0.2.2",
+    "encodeurl": "^1.0.1",
+    "formstream": "1.1.0",
+    "mime": "1.3.6",
     "tunnel-agent": "0.6.0",
-    "urlencode": "1.1.0"
+    "urllib": "2.22.0"
   },
   "devDependencies": {
     "@types/node": "^8.0.3",

--- a/qiniu/cdn.js
+++ b/qiniu/cdn.js
@@ -3,7 +3,7 @@ const crypto = require('crypto');
 const urllib = require('urllib');
 const util = require('./util');
 const digest = require('./auth/digest.js');
-const urlencode = require('urlencode');
+const encodeUrl = require('encodeurl');
 
 exports.CdnManager = CdnManager;
 
@@ -161,9 +161,9 @@ function req(reqPath, header, reqBody, callbackFunc) {
 CdnManager.prototype.createTimestampAntiLeechUrl = function(domain, fileName,
   query, encryptKey, deadline) {
   if (query != null) {
-    urlToSign = domain + '/' + url_encode(fileName) + '?' + query;
+    urlToSign = domain + '/' + encodeUrl(fileName) + '?' + query;
   } else {
-    urlToSign = domain + '/' + url_encode(fileName);
+    urlToSign = domain + '/' + encodeUrl(fileName);
   }
 
   var urlObj = url.parse(urlToSign);
@@ -180,10 +180,4 @@ CdnManager.prototype.createTimestampAntiLeechUrl = function(domain, fileName,
   } else {
     return urlToSign + '?sign=' + toSignStr + '&t=' + expireHex;
   }
-}
-
-function url_encode(url){
-    url = encodeURI(url);
-    url = url.replace(/\'/g, "%27");
-    return url;
 }

--- a/qiniu/storage/rs.js
+++ b/qiniu/storage/rs.js
@@ -2,6 +2,7 @@ const url = require('url');
 const crypto = require('crypto');
 const formstream = require('formstream');
 const querystring = require('querystring');
+const encodeUrl = require('encodeurl');
 const rpc = require('../rpc');
 const conf = require('../conf');
 const digest = require('../auth/digest');
@@ -648,7 +649,7 @@ BucketManager.prototype.privateDownloadUrl = function(domain, fileName,
 // @param fileName 原始文件名
 // @return 公开下载链接
 BucketManager.prototype.publicDownloadUrl = function(domain, fileName) {
-  return domain + "/" + encodeURI(fileName);
+  return domain + '/' + encodeUrl(fileName);
 
 }
 


### PR DESCRIPTION
File name with character `?` or `#` is valid, but `encodeURI` not encode these characters. I use [encodeurl](https://www.npmjs.com/package/encodeurl) instead of `encodeURI`, so I could encode these characters before.

```
const key = '/test/hello#world.js';
const query = '?imageView2/2/w/800';
manager.privateDownloadUrl(domain, key.replace(/#/g, '%23') + query, deadline);
```