### PR TITLE
fix: mime.lookup is not a function

### DIFF
--- a/qiniu/storage/form.js
+++ b/qiniu/storage/form.js
@@ -173,7 +173,7 @@ FormUploader.prototype.putFile = function(uploadToken, key, localFile, putExtra,
   var fsStream = fs.createReadStream(localFile);
 
   if (!putExtra.mimeType) {
-    putExtra.mimeType = mime.lookup(localFile);
+    putExtra.mimeType = mime.getType(localFile);
   }
 
   if (!putExtra.fname) {


### PR DESCRIPTION
升级mime后，原来的`mime.lookup`需要修改为`mime.getType`，贵司忘记修改`./storage/form.js`中的代码了

```
TypeError: mime.lookup is not a function
    at FormUploader.putFile (./storage/form.js:176:30)
    ...
```
