### PR TITLE
Fix ConfigOptions.zone type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- '4'
 - '6'
 - '8'
 before_script:

--- a/index.d.ts
+++ b/index.d.ts
@@ -128,7 +128,7 @@ export declare namespace conf {
         /**
          * @default null
          */
-        zone?: 'huadong' | 'huabei' | 'huanan' | 'beimei';
+        zone?: Zone,
 
         /**
          * @default -1


### PR DESCRIPTION
`'huadong' | 'huabei' | 'huanan' | 'beimei'` 可能是老的写法？改成直接传 `Zone` 了