### PR TITLE
fix unexpected file size

### DIFF
--- a/qiniu/storage/resume.js
+++ b/qiniu/storage/resume.js
@@ -128,7 +128,6 @@ function putReq (config, uploadToken, key, rsStream, rsStreamLen, putExtra,
     var blockCnt = fileSize / conf.BLOCK_SIZE;
     var totalBlockNum = (fileSize % conf.BLOCK_SIZE == 0) ? blockCnt : (blockCnt +
     1);
-    console.log(blkStream.size);
     // read resumeRecordFile
     if (putExtra.resumeRecordFile) {
         try {

--- a/qiniu/storage/resume.js
+++ b/qiniu/storage/resume.js
@@ -117,11 +117,18 @@ function putReq (config, uploadToken, key, rsStream, rsStreamLen, putExtra,
         size: conf.BLOCK_SIZE,
         zeroPadding: false
     }));
+
     var readLen = 0;
     var curBlock = 0;
     var finishedBlock = 0;
     var finishedCtxList = [];
     var finishedBlkPutRets = [];
+    var isSent = false;
+    var fileSize = rsStreamLen;
+    var blockCnt = fileSize / conf.BLOCK_SIZE;
+    var totalBlockNum = (fileSize % conf.BLOCK_SIZE == 0) ? blockCnt : (blockCnt +
+    1);
+    console.log(blkStream.size);
     // read resumeRecordFile
     if (putExtra.resumeRecordFile) {
         try {
@@ -177,13 +184,19 @@ function putReq (config, uploadToken, key, rsStream, rsStreamLen, putExtra,
                         });
                     }
                     blkStream.resume();
+                    if (finishedCtxList.length === Math.floor(totalBlockNum)) {
+                        mkfileReq(upDomain, uploadToken, fileSize, finishedCtxList, key, putExtra, callbackFunc);
+                        isSent = true;
+                    }
                 }
             });
         }
     });
 
     blkStream.on('end', function () {
-        mkfileReq(upDomain, uploadToken, rsStreamLen, finishedCtxList, key, putExtra, callbackFunc);
+        if (!isSent && rsStreamLen === 0) {
+            mkfileReq(upDomain, uploadToken, rsStreamLen, finishedCtxList, key, putExtra, callbackFunc);
+        }
         destroy(rsStream);
     });
 }


### PR DESCRIPTION
readStream触发data事件时，最后一块读取完毕，触发end事件，开始调mkfile。

而此时最后一块的mkblock还未回调回来，导致mkfile时的finishedCtxList.length少一个，报unexpected file size