### PR TITLE
chore: Custome http(s) request timeout support

### DIFF
--- a/qiniu/zone.js
+++ b/qiniu/zone.js
@@ -59,10 +59,18 @@ exports.Zone_as0 = new conf.Zone([
 'rsf-as0.qbox.me',
 'api-as0.qiniu.com');
 
+const REQUEST_OPTIONS = {
+
+};
+
+if (process.env.QINIU_NODESDK_REQUEST_MIN_TIMEOUT_MS) {
+    REQUEST_OPTIONS.timeout = parseInt(process.env.QINIU_NODESDK_REQUEST_MIN_TIMEOUT_MS, 10);
+}
+
 exports.getZoneInfo = function (accessKey, bucket, callbackFunc) {
     var apiAddr = util.format('https://uc.qbox.me/v2/query?ak=%s&bucket=%s',
         accessKey, bucket);
-    urllib.request(apiAddr, function (respErr, respData, respInfo) {
+    urllib.request(apiAddr, REQUEST_OPTIONS, function (respErr, respData, respInfo) {
         if (respErr) {
             callbackFunc(respErr, null, null);
             return;


### PR DESCRIPTION
Related: #365 


### 背景描述
![image](https://user-images.githubusercontent.com/20190812/88134042-317f6200-cc16-11ea-9272-cf8a8f7fc26c.png)
当我进行多文件上传时. 经常会因为 zone request timeout 导致上传错误.

通过查看源码发现.  https://github.com/qiniu/nodejs-sdk/blob/master/qiniu/zone.js#L65 没有设置请求超时时间. 默认的话 urllib 的超时时间为 `5000ms`. 当我在进行大量文件同时上传的时候, 由于带宽占用. 请求经常会超出 `5000ms`. 

所以需要可以支持 用户自定义请求超时时间.  可以增加一个环境变量之类的. `QINIU_NODESDK_REQUEST_MIN_TIMEOUT`.