### PR TITLE
feat(sandbox): sync latest sandbox APIs

### DIFF
--- a/examples/sandbox_list_connect.js
+++ b/examples/sandbox_list_connect.js
@@ -1,16 +1,19 @@
 const {
     qiniu,
     sandboxClient,
+    sandboxTemplate,
     cleanupSandbox,
     runExample
 } = require('./sandbox_common');
 
 runExample(() => {
     const client = sandboxClient();
+    const template = sandboxTemplate();
     let sandbox;
 
     return qiniu.sandbox.Sandbox.create({
         client,
+        template,
         timeout: 300,
         metadata: {
             example: 'sandbox_list_connect'
@@ -20,7 +23,10 @@ runExample(() => {
         console.log('Created:', sandbox.sandboxId);
         return qiniu.sandbox.Sandbox.list({
             client,
-            limit: 10
+            limit: 10,
+            query: {
+                template: [template]
+            }
         });
     }).then(items => {
         console.log('List result:', Array.isArray(items) ? items.map(item => item.sandboxId || item.sandboxID) : items);

--- a/examples/sandbox_request_injections.js
+++ b/examples/sandbox_request_injections.js
@@ -7,25 +7,29 @@ const {
 
 runExample(() => {
     let sandbox;
+    const httpInjection = {
+        type: 'http',
+        baseUrl: 'https://httpbin.org/bearer',
+        ifHeaders: {
+            'X-Sandbox-Example': 'qiniu-nodejs-sdk'
+        },
+        headers: {
+            Authorization: `Bearer ${env('QINIU_SANDBOX_HTTP_INJECTION_TOKEN', 'real_token')}`
+        }
+    };
 
     return createSandboxAndWait({
-        injections: [
-            {
-                type: 'http',
-                baseUrl: 'https://httpbin.org/bearer',
-                ifHeaders: {
-                    'X-Sandbox-Example': 'qiniu-nodejs-sdk'
-                },
-                headers: {
-                    Authorization: `Bearer ${env('QINIU_SANDBOX_HTTP_INJECTION_TOKEN', 'real_token')}`
-                }
-            }
-        ],
+        injections: [httpInjection],
         metadata: {
             example: 'sandbox_request_injections'
         }
     }).then(created => {
         sandbox = created;
+        return sandbox.getInjections();
+    }).then(result => {
+        console.log('Current runtime injections:', result.injections);
+        return sandbox.updateInjections([httpInjection]);
+    }).then(() => {
         return sandbox.commands.run('curl --max-time 20 -sSL https://httpbin.org/bearer -H "Authorization: Bearer fake_token" -H "X-Sandbox-Example: qiniu-nodejs-sdk"', {
             timeout: 30000
         });

--- a/examples/sandbox_resources.js
+++ b/examples/sandbox_resources.js
@@ -41,6 +41,9 @@ function runGitResourceExample () {
         return sandbox.waitForReady({ interval: 3000, timeout: 180000 });
     }).then(() => {
         console.log('Git resource sandbox ready:', sandbox.sandboxId);
+        return sandbox.updateGithubToken(token);
+    }).then(() => {
+        console.log('GitHub token updated for the running sandbox.');
         return sandbox.commands.run(`ls -la ${shellQuote(mountPath)} | head -20`);
     }).then(result => {
         console.log(result.stdout);

--- a/examples/sandbox_templates.js
+++ b/examples/sandbox_templates.js
@@ -25,7 +25,13 @@ runExample(() => {
         }
         const id = first.templateID || first.template_id || first.id || sandboxTemplate();
         return client.getTemplate(id).then(detail => {
-            console.log('First template detail:', detail.templateID || detail.template_id || id);
+            console.log('First template detail:', {
+                templateID: detail.templateID || detail.template_id || id,
+                names: detail.names,
+                aliases: detail.aliases,
+                isOwner: detail.isOwner,
+                buildCount: Array.isArray(detail.builds) ? detail.builds.length : 0
+            });
         });
     }).then(() => {
         const advanced = qiniu.sandbox.Template()

--- a/index.d.ts
+++ b/index.d.ts
@@ -130,6 +130,24 @@ export declare namespace sandbox {
     type Injection = HttpInjection | OpenaiInjection | AnthropicInjection | GeminiInjection | QiniuInjection | GithubInjection;
     type SandboxInjection = InjectionById | InjectionRuleReference | Injection;
 
+    interface SandboxInjectionsResponse {
+        injections: SandboxInjection[];
+    }
+
+    interface TemplateInfo {
+        templateID: string;
+        public: boolean;
+        /** @deprecated use names instead */
+        aliases: string[];
+        names: string[];
+        [key: string]: any;
+    }
+
+    interface TemplateWithBuilds extends TemplateInfo {
+        isOwner: boolean;
+        builds: any[];
+    }
+
     interface InjectionRule {
         ruleID?: string;
         id?: string;
@@ -456,6 +474,9 @@ export declare namespace sandbox {
         getSandboxesMetrics(sandboxIDs: string[] | any): Promise<any>;
         getSandboxLogs(sandboxID: string, options?: any): Promise<any>;
         getSandbox(sandboxID: string): Promise<any>;
+        getSandboxInjections(sandboxID: string): Promise<SandboxInjectionsResponse>;
+        updateSandboxInjections(sandboxID: string, injections: SandboxInjection[]): Promise<null>;
+        updateSandboxGithubToken(sandboxID: string, authorizationToken: string): Promise<null>;
         deleteSandbox(sandboxID: string): Promise<null>;
         killSandbox(sandboxID: string): Promise<null>;
         getSandboxMetrics(sandboxID: string, options?: any): Promise<any>;
@@ -472,7 +493,7 @@ export declare namespace sandbox {
         getTemplateFiles(templateID: string, hash: string): Promise<any>;
         listDefaultTemplates(): Promise<any>;
         listTemplates(options?: any): Promise<any>;
-        getTemplate(templateID: string, options?: any): Promise<any>;
+        getTemplate(templateID: string, options?: any): Promise<TemplateWithBuilds>;
         deleteTemplate(templateID: string): Promise<null>;
         updateTemplate(templateID: string, options?: any): Promise<any>;
         startTemplateBuildV2(templateID: string, buildID: string, options?: any): Promise<null>;
@@ -536,6 +557,9 @@ export declare namespace sandbox {
         betaPause(): Promise<null>;
         connect(options?: SandboxConnectOptions): Promise<this>;
         getInfo(): Promise<any>;
+        getInjections(): Promise<SandboxInjectionsResponse>;
+        updateInjections(injections: SandboxInjection[]): Promise<null>;
+        updateGithubToken(authorizationToken: string): Promise<null>;
         getMetrics(options?: any): Promise<any>;
         getLogs(options?: any): Promise<any>;
         createSnapshot(options?: any): Promise<SnapshotInfo>;

--- a/qiniu/sandbox/client.js
+++ b/qiniu/sandbox/client.js
@@ -101,7 +101,23 @@ function normalizeSandboxListOptions (opts) {
         opts.state = query.state;
     }
     if (query && query.template) {
-        opts.template = query.template;
+        const normalizeTemplate = template => {
+            if (typeof template === 'string') {
+                return template;
+            }
+            return template && (template.templateID || template.template_id || template.id);
+        };
+        if (Array.isArray(query.template)) {
+            const templates = query.template.map(normalizeTemplate).filter(Boolean);
+            if (templates.length) {
+                opts.template = templates;
+            }
+        } else {
+            const template = normalizeTemplate(query.template);
+            if (template) {
+                opts.template = template;
+            }
+        }
     }
     return opts;
 }
@@ -292,6 +308,9 @@ SandboxClient.prototype.updateSandboxInjections = function (sandboxID, injection
     }
     if (!Array.isArray(injections)) {
         return Promise.reject(new SandboxError('injections must be an array'));
+    }
+    if (injections.some(injection => !injection || typeof injection !== 'object' || Array.isArray(injection))) {
+        return Promise.reject(new SandboxError('injections must contain objects'));
     }
     return this._request('PUT', `/sandboxes/${encodePath(sandboxID)}/injections`, {
         body: {

--- a/qiniu/sandbox/client.js
+++ b/qiniu/sandbox/client.js
@@ -100,6 +100,9 @@ function normalizeSandboxListOptions (opts) {
     if (query && query.state) {
         opts.state = query.state;
     }
+    if (query && query.template) {
+        opts.template = query.template;
+    }
     return opts;
 }
 
@@ -274,6 +277,28 @@ SandboxClient.prototype.getSandbox = function (sandboxID) {
         return Promise.reject(new SandboxError('sandboxID is required'));
     }
     return this._request('GET', `/sandboxes/${encodePath(sandboxID)}`);
+};
+
+SandboxClient.prototype.getSandboxInjections = function (sandboxID) {
+    return this._request('GET', `/sandboxes/${encodePath(sandboxID)}/injections`);
+};
+
+SandboxClient.prototype.updateSandboxInjections = function (sandboxID, injections) {
+    return this._request('PUT', `/sandboxes/${encodePath(sandboxID)}/injections`, {
+        body: {
+            injections: (injections || []).map(normalizeInjection)
+        },
+        empty: true
+    });
+};
+
+SandboxClient.prototype.updateSandboxGithubToken = function (sandboxID, authorizationToken) {
+    return this._request('PUT', `/sandboxes/${encodePath(sandboxID)}/github-token`, {
+        body: {
+            authorization_token: authorizationToken
+        },
+        empty: true
+    });
 };
 
 SandboxClient.prototype.deleteSandbox = function (sandboxID) {

--- a/qiniu/sandbox/client.js
+++ b/qiniu/sandbox/client.js
@@ -305,6 +305,9 @@ SandboxClient.prototype.updateSandboxGithubToken = function (sandboxID, authoriz
     if (!sandboxID) {
         return Promise.reject(new SandboxError('sandboxID is required'));
     }
+    if (!authorizationToken) {
+        return Promise.reject(new SandboxError('authorizationToken is required'));
+    }
     return this._request('PUT', `/sandboxes/${encodePath(sandboxID)}/github-token`, {
         body: {
             authorization_token: authorizationToken

--- a/qiniu/sandbox/client.js
+++ b/qiniu/sandbox/client.js
@@ -280,19 +280,31 @@ SandboxClient.prototype.getSandbox = function (sandboxID) {
 };
 
 SandboxClient.prototype.getSandboxInjections = function (sandboxID) {
+    if (!sandboxID) {
+        return Promise.reject(new SandboxError('sandboxID is required'));
+    }
     return this._request('GET', `/sandboxes/${encodePath(sandboxID)}/injections`);
 };
 
 SandboxClient.prototype.updateSandboxInjections = function (sandboxID, injections) {
+    if (!sandboxID) {
+        return Promise.reject(new SandboxError('sandboxID is required'));
+    }
+    if (!Array.isArray(injections)) {
+        return Promise.reject(new SandboxError('injections must be an array'));
+    }
     return this._request('PUT', `/sandboxes/${encodePath(sandboxID)}/injections`, {
         body: {
-            injections: (injections || []).map(normalizeInjection)
+            injections: injections.map(normalizeInjection)
         },
         empty: true
     });
 };
 
 SandboxClient.prototype.updateSandboxGithubToken = function (sandboxID, authorizationToken) {
+    if (!sandboxID) {
+        return Promise.reject(new SandboxError('sandboxID is required'));
+    }
     return this._request('PUT', `/sandboxes/${encodePath(sandboxID)}/github-token`, {
         body: {
             authorization_token: authorizationToken

--- a/qiniu/sandbox/sandbox.js
+++ b/qiniu/sandbox/sandbox.js
@@ -216,6 +216,18 @@ Sandbox.prototype.getInfo = function () {
     return this.client.getSandbox(this.sandboxId);
 };
 
+Sandbox.prototype.getInjections = function () {
+    return this.client.getSandboxInjections(this.sandboxId);
+};
+
+Sandbox.prototype.updateInjections = function (injections) {
+    return this.client.updateSandboxInjections(this.sandboxId, injections);
+};
+
+Sandbox.prototype.updateGithubToken = function (authorizationToken) {
+    return this.client.updateSandboxGithubToken(this.sandboxId, authorizationToken);
+};
+
 Sandbox.prototype.refreshEnvdTokenIfNeeded = function () {
     if (this.envdAccessToken) {
         return Promise.resolve(this);

--- a/test/sandbox_client.test.js
+++ b/test/sandbox_client.test.js
@@ -553,6 +553,73 @@ describe('test sandbox client module', function () {
         });
     });
 
+    it('maps sandbox template filters and runtime injection APIs', function () {
+        return startServer((req, res) => {
+            res.setHeader('Content-Type', 'application/json');
+            if (req.method === 'GET' && req.url === '/v2/sandboxes?limit=5&template=tpl_1%2Ctpl_2') {
+                res.statusCode = 200;
+                res.end(JSON.stringify([]));
+                return;
+            }
+            if (req.method === 'GET' && req.url === '/sandboxes/sbx_runtime/injections') {
+                res.statusCode = 200;
+                res.end(JSON.stringify({
+                    injections: [{ type: 'github', token: 'ghp_****' }]
+                }));
+                return;
+            }
+            if (req.method === 'PUT' && req.url === '/sandboxes/sbx_runtime/injections') {
+                res.statusCode = 204;
+                res.end();
+                return;
+            }
+            if (req.method === 'PUT' && req.url === '/sandboxes/sbx_runtime/github-token') {
+                res.statusCode = 204;
+                res.end();
+                return;
+            }
+            res.statusCode = 404;
+            res.end(JSON.stringify({ message: req.method + ' ' + req.url }));
+        }).then(fixture => {
+            const client = new qiniu.sandbox.SandboxClient({
+                endpoint: fixture.endpoint,
+                apiKey: 'sandbox-key'
+            });
+
+            return client.listSandboxesV2({
+                limit: 5,
+                query: {
+                    template: ['tpl_1', 'tpl_2']
+                }
+            }).then(() => client.getSandboxInjections('sbx_runtime'))
+                .then(result => {
+                    result.injections[0].token.should.eql('ghp_****');
+                    return client.updateSandboxInjections('sbx_runtime', [{
+                        type: 'openai',
+                        apiKey: 'secret',
+                        baseUrl: 'https://api.openai.com/v1/*'
+                    }]);
+                })
+                .then(() => client.updateSandboxGithubToken('sbx_runtime', 'github-token'))
+                .then(() => {
+                    JSON.parse(fixture.requests[2].body).should.eql({
+                        injections: [{
+                            type: 'openai',
+                            api_key: 'secret',
+                            base_url: 'https://api.openai.com/v1/*'
+                        }]
+                    });
+                    JSON.parse(fixture.requests[3].body).should.eql({
+                        authorization_token: 'github-token'
+                    });
+                }).then(() => closeServer(fixture.server), err => {
+                    return closeServer(fixture.server).then(() => {
+                        throw err;
+                    });
+                });
+        });
+    });
+
     it('surfaces sandbox API string errors and default connect timeout', function () {
         return startServer((req, res) => {
             if (req.method === 'POST' && req.url === '/sandboxes/sbx_default/connect') {

--- a/test/sandbox_client.test.js
+++ b/test/sandbox_client.test.js
@@ -620,6 +620,39 @@ describe('test sandbox client module', function () {
         });
     });
 
+    it('validates runtime injection API arguments before sending requests', function () {
+        return startServer((req, res) => {
+            res.statusCode = 404;
+            res.end();
+        }).then(fixture => {
+            const client = new qiniu.sandbox.SandboxClient({
+                endpoint: fixture.endpoint,
+                apiKey: 'sandbox-key'
+            });
+            const calls = [
+                () => client.getSandboxInjections(),
+                () => client.updateSandboxInjections(undefined, []),
+                () => client.updateSandboxGithubToken(undefined, 'github-token'),
+                () => client.updateSandboxInjections('sbx_runtime', { type: 'id', id: 'rule_1' })
+            ];
+
+            return calls.reduce((promise, call, index) => {
+                return promise.then(() => call().then(() => {
+                    throw new Error('expected runtime injection argument validation to fail');
+                }, err => {
+                    err.name.should.eql('SandboxError');
+                    err.message.should.eql(index < 3 ? 'sandboxID is required' : 'injections must be an array');
+                }));
+            }, Promise.resolve()).then(() => {
+                fixture.requests.should.have.length(0);
+            }).then(() => closeServer(fixture.server), err => {
+                return closeServer(fixture.server).then(() => {
+                    throw err;
+                });
+            });
+        });
+    });
+
     it('surfaces sandbox API string errors and default connect timeout', function () {
         return startServer((req, res) => {
             if (req.method === 'POST' && req.url === '/sandboxes/sbx_default/connect') {

--- a/test/sandbox_client.test.js
+++ b/test/sandbox_client.test.js
@@ -633,7 +633,8 @@ describe('test sandbox client module', function () {
                 () => client.getSandboxInjections(),
                 () => client.updateSandboxInjections(undefined, []),
                 () => client.updateSandboxGithubToken(undefined, 'github-token'),
-                () => client.updateSandboxInjections('sbx_runtime', { type: 'id', id: 'rule_1' })
+                () => client.updateSandboxInjections('sbx_runtime', { type: 'id', id: 'rule_1' }),
+                () => client.updateSandboxGithubToken('sbx_runtime')
             ];
 
             return calls.reduce((promise, call, index) => {
@@ -641,7 +642,10 @@ describe('test sandbox client module', function () {
                     throw new Error('expected runtime injection argument validation to fail');
                 }, err => {
                     err.name.should.eql('SandboxError');
-                    err.message.should.eql(index < 3 ? 'sandboxID is required' : 'injections must be an array');
+                    const expected = index < 3
+                        ? 'sandboxID is required'
+                        : (index === 3 ? 'injections must be an array' : 'authorizationToken is required');
+                    err.message.should.eql(expected);
                 }));
             }, Promise.resolve()).then(() => {
                 fixture.requests.should.have.length(0);

--- a/test/sandbox_client.test.js
+++ b/test/sandbox_client.test.js
@@ -556,7 +556,7 @@ describe('test sandbox client module', function () {
     it('maps sandbox template filters and runtime injection APIs', function () {
         return startServer((req, res) => {
             res.setHeader('Content-Type', 'application/json');
-            if (req.method === 'GET' && req.url === '/v2/sandboxes?limit=5&template=tpl_1%2Ctpl_2') {
+            if (req.method === 'GET' && req.url === '/v2/sandboxes?limit=5&template=tpl_1%2Ctpl_2%2Ctpl_3%2Ctpl_4') {
                 res.statusCode = 200;
                 res.end(JSON.stringify([]));
                 return;
@@ -589,7 +589,13 @@ describe('test sandbox client module', function () {
             return client.listSandboxesV2({
                 limit: 5,
                 query: {
-                    template: ['tpl_1', 'tpl_2']
+                    template: [
+                        'tpl_1',
+                        { templateID: 'tpl_2' },
+                        { template_id: 'tpl_3' },
+                        { id: 'tpl_4' },
+                        null
+                    ]
                 }
             }).then(() => client.getSandboxInjections('sbx_runtime'))
                 .then(result => {
@@ -634,7 +640,8 @@ describe('test sandbox client module', function () {
                 () => client.updateSandboxInjections(undefined, []),
                 () => client.updateSandboxGithubToken(undefined, 'github-token'),
                 () => client.updateSandboxInjections('sbx_runtime', { type: 'id', id: 'rule_1' }),
-                () => client.updateSandboxGithubToken('sbx_runtime')
+                () => client.updateSandboxGithubToken('sbx_runtime'),
+                () => client.updateSandboxInjections('sbx_runtime', [null])
             ];
 
             return calls.reduce((promise, call, index) => {
@@ -644,7 +651,9 @@ describe('test sandbox client module', function () {
                     err.name.should.eql('SandboxError');
                     const expected = index < 3
                         ? 'sandboxID is required'
-                        : (index === 3 ? 'injections must be an array' : 'authorizationToken is required');
+                        : (index === 3
+                            ? 'injections must be an array'
+                            : (index === 4 ? 'authorizationToken is required' : 'injections must contain objects'));
                     err.message.should.eql(expected);
                 }));
             }, Promise.resolve()).then(() => {

--- a/test/sandbox_facade.test.js
+++ b/test/sandbox_facade.test.js
@@ -5,6 +5,51 @@ const {
 } = require('./sandbox_helpers');
 
 describe('test sandbox facade module', function () {
+    it('manages runtime injections and GitHub tokens through Sandbox instances', function () {
+        return startServer((req, res) => {
+            res.setHeader('Content-Type', 'application/json');
+            if (req.method === 'GET' && req.url === '/sandboxes/sbx_runtime/injections') {
+                res.statusCode = 200;
+                res.end(JSON.stringify({ injections: [{ type: 'id', id: 'rule_1' }] }));
+                return;
+            }
+            if (req.method === 'PUT' && (req.url === '/sandboxes/sbx_runtime/injections' || req.url === '/sandboxes/sbx_runtime/github-token')) {
+                res.statusCode = 204;
+                res.end();
+                return;
+            }
+            res.statusCode = 404;
+            res.end(JSON.stringify({ message: req.method + ' ' + req.url }));
+        }).then(fixture => {
+            const sandbox = new qiniu.sandbox.Sandbox({
+                sandboxId: 'sbx_runtime',
+                client: new qiniu.sandbox.SandboxClient({
+                    endpoint: fixture.endpoint,
+                    apiKey: 'sandbox-key'
+                }),
+                info: {}
+            });
+
+            return sandbox.getInjections()
+                .then(result => {
+                    result.injections[0].id.should.eql('rule_1');
+                    return sandbox.updateInjections([{ type: 'id', id: 'rule_2' }]);
+                })
+                .then(() => sandbox.updateGithubToken('github-token'))
+                .then(() => {
+                    fixture.requests.map(req => `${req.method} ${req.url}`).should.eql([
+                        'GET /sandboxes/sbx_runtime/injections',
+                        'PUT /sandboxes/sbx_runtime/injections',
+                        'PUT /sandboxes/sbx_runtime/github-token'
+                    ]);
+                }).then(() => closeServer(fixture.server), err => {
+                    return closeServer(fixture.server).then(() => {
+                        throw err;
+                    });
+                });
+        });
+    });
+
     it('covers Sandbox.connect, Sandbox.list, wait polling, and stopped health checks', function () {
         let infoCalls = 0;
         return startServer((req, res) => {

--- a/test/sandbox_template.test.js
+++ b/test/sandbox_template.test.js
@@ -32,7 +32,14 @@ describe('test sandbox template module', function () {
             }
             if (req.method === 'GET' && req.url === '/templates/tpl_1?limit=5&nextToken=n2') {
                 res.statusCode = 200;
-                res.end(JSON.stringify({ templateID: 'tpl_1' }));
+                res.end(JSON.stringify({
+                    templateID: 'tpl_1',
+                    public: true,
+                    aliases: ['nodejs'],
+                    names: ['qiniu/nodejs'],
+                    isOwner: true,
+                    builds: []
+                }));
                 return;
             }
             if (req.method === 'PATCH' && req.url === '/templates/tpl_1') {
@@ -99,6 +106,12 @@ describe('test sandbox template module', function () {
                 .then(() => client.createTemplate({ name: 'node:v1' }))
                 .then(() => client.createTemplateV2({ alias: 'old' }))
                 .then(() => client.getTemplate('tpl_1', { limit: 5, nextToken: 'n2' }))
+                .then(template => {
+                    template.names.should.eql(['qiniu/nodejs']);
+                    template.aliases.should.eql(['nodejs']);
+                    template.isOwner.should.eql(true);
+                    template.builds.should.eql([]);
+                })
                 .then(() => client.updateTemplate('tpl_1', { public: true }))
                 .then(() => client.deleteTemplate('tpl_1'))
                 .then(() => client.getTemplateFiles('tpl_1', 'hash'))

--- a/test/sandbox_types.ts
+++ b/test/sandbox_types.ts
@@ -136,6 +136,13 @@ async function useSandboxTypes () {
         .runCmd(['echo one', 'echo two'], { user: 'root' });
     await template.build({ client, name: 'typed-template:test' });
     await sandbox.updateNetwork({ allowOut: [qiniu.sandbox.ALL_TRAFFIC] });
+    const injections: qiniu.sandbox.SandboxInjection[] = (await sandbox.getInjections()).injections;
+    await sandbox.updateInjections(injections);
+    await sandbox.updateGithubToken('github-token');
+    const templateInfo: qiniu.sandbox.TemplateWithBuilds = await client.getTemplate('typed-template');
+    const templateNames: string[] = templateInfo.names;
+    const isOwner: boolean = templateInfo.isOwner;
+    qiniu.Sandbox.list({ client, query: { template: templateNames } });
     qiniu.CommandExitError.name;
     bytes.length;
     text.length;
@@ -144,6 +151,9 @@ async function useSandboxTypes () {
     eventType.length;
     if (gitUser) {
         gitUser.length;
+    }
+    if (isOwner) {
+        isOwner.valueOf();
     }
 }
 


### PR DESCRIPTION
## Summary
- follow qiniu/api-specs#21 with sandbox template filters and typed template ownership/name fields
- follow qiniu/api-specs#22 with runtime injection query/replace APIs and GitHub token updates
- expose matching Sandbox instance helpers and keep camelCase request normalization
- expand TypeScript declarations, unit coverage, and executable examples

## Validation
- `npm run test:sandbox` (121 passing)
- `npm run check-type`
- targeted ESLint for all changed JavaScript files
- `git diff --check`
- live sandbox smoke: template-filtered listing, template `names`/`isOwner`, runtime injection get/update, GitHub token update, and Kodo resource mounting/writes

## Live smoke notes
- the runtime injection APIs succeeded; the downstream httpbin request returned `Bad Gateway` in the current sandbox environment
- GitHub repository resource creation returned 401 with the current repo/token pair, while `updateGithubToken()` was verified independently against the live API
