### PR TITLE
chore(release): bump version to 7.15.5

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ docs/
 examples/
 coverage/
 .nyc_output/
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGE LOG
 
+## 7.15.5
+- 沙箱列表支持按模板筛选
+- 沙箱实例支持查询和更新运行时请求注入配置，并支持更新 GitHub Token
+
 ## 7.15.4
 - 沙箱请求注入支持 `baseUrl` 路径前缀匹配和 `ifHeaders`、`ifQueries` 条件匹配
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qiniu",
-  "version": "7.15.4",
+  "version": "7.15.5",
   "description": "Node wrapper for Qiniu Resource (Cloud) Storage API",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## Summary
- bump package version to 7.15.5
- document sandbox template filtering, runtime injection updates, and GitHub token updates
- exclude local `.env` files from npm packages

## Validation
- `npm run check-type`
- `npm run test:sandbox` (122 passing)
- `npm pack --dry-run --json` (confirmed `.env` is excluded)